### PR TITLE
Add OpenAI sample agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-Shows usage of  Strands agents https://strandsagents.com/latest/
+# Strands Codex Samples
+
+This repository demonstrates basic usage of the
+[Strands Agents](https://strandsagents.com/latest/) SDK.
+
+## Samples
+
+- **OpenAI Recipe Bot** – A command line agent that uses OpenAI and a web search
+  tool. See [samples/openai_recipe_bot](samples/openai_recipe_bot).

--- a/samples/openai_recipe_bot/README.md
+++ b/samples/openai_recipe_bot/README.md
@@ -1,0 +1,26 @@
+# OpenAI Recipe Bot Sample
+
+This example demonstrates how to build a simple Strands agent using OpenAI.
+The agent acts as a cooking assistant and can search the web for recipes
+using a `websearch` tool built with `duckduckgo-search`.
+
+## Setup
+
+1. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a `.env` file in this directory and add your OpenAI API key:
+   ```bash
+   OPENAI_API_KEY=sk-your-key
+   ```
+
+## Running the Bot
+
+Run the `recipe_bot.py` script:
+
+```bash
+python recipe_bot.py
+```
+
+Interact with the bot at the command line. Type `exit` to quit.

--- a/samples/openai_recipe_bot/recipe_bot.py
+++ b/samples/openai_recipe_bot/recipe_bot.py
@@ -1,0 +1,70 @@
+from strands import Agent, tool
+from duckduckgo_search import DDGS
+from duckduckgo_search.exceptions import RatelimitException, DuckDuckGoSearchException
+from dotenv import load_dotenv
+import os
+
+
+@tool
+def websearch(keywords: str, region: str = "us-en", max_results: int | None = None) -> str:
+    """Search the web to get updated information.
+
+    Args:
+        keywords: The search query keywords.
+        region: Search region code like ``us-en``.
+        max_results: Limit on number of results.
+
+    Returns:
+        Search results text or an error message.
+    """
+    try:
+        results = DDGS().text(keywords, region=region, max_results=max_results)
+        return results if results else "No results found."
+    except RatelimitException:
+        return "RatelimitException: Please try again after a short delay."
+    except DuckDuckGoSearchException as exc:
+        return f"DuckDuckGoSearchException: {exc}"
+    except Exception as exc:  # pragma: no cover - generic safety
+        return f"Exception: {exc}"
+
+
+def get_agent() -> Agent:
+    """Create a RecipeBot agent using OpenAI."""
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+
+    model = None
+    if api_key:
+        from strands.models.openai import OpenAIModel
+
+        model = OpenAIModel(
+            client_args={"api_key": api_key},
+            model_id="gpt-4o",
+        )
+
+    return Agent(
+        system_prompt=(
+            "You are RecipeBot, a helpful cooking assistant. "
+            "Use the websearch tool to find recipes when users provide ingredients "
+            "or to look up cooking information."
+        ),
+        model=model,
+        tools=[websearch],
+    )
+
+
+def main() -> None:
+    agent = get_agent()
+    print("\n👨‍🍳 RecipeBot: Ask me about recipes or cooking! Type 'exit' to quit.\n")
+
+    while True:
+        user_input = input("\nYou > ")
+        if user_input.lower() == "exit":
+            print("Happy cooking! 🍽️")
+            break
+        response = agent(user_input)
+        print(f"\nRecipeBot > {response}")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/openai_recipe_bot/requirements.txt
+++ b/samples/openai_recipe_bot/requirements.txt
@@ -1,0 +1,5 @@
+strands-agents
+strands-agents-tools
+duckduckgo-search
+openai
+python-dotenv


### PR DESCRIPTION
## Summary
- add a minimal sample agent that uses OpenAI with a websearch tool
- document how to run the sample
- update the root README with a link to the sample

## Testing
- `python -m py_compile samples/openai_recipe_bot/recipe_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_684244416c48832095efe42b7ea6638f